### PR TITLE
Use feature group for NDVI draw tool

### DIFF
--- a/project/app/modules/agrovista/templates/agrovista/ndvi-tool.j2
+++ b/project/app/modules/agrovista/templates/agrovista/ndvi-tool.j2
@@ -43,7 +43,12 @@
   <script>
     let imgId = null, imgWidth = 0, imgHeight = 0;
     const map = L.map('map', { crs: L.CRS.Simple }).setView([0,0], 0);
-    const drawCtl = new L.Control.Draw({ draw: { polygon:true, rectangle:true, polyline:false, circle:false, marker:false }});
+    const drawnItems = new L.FeatureGroup();
+    map.addLayer(drawnItems);
+    const drawCtl = new L.Control.Draw({
+      draw: { polygon: true, rectangle: true, polyline: false, circle: false, marker: false },
+      edit: { featureGroup: drawnItems }
+    });
     map.addControl(drawCtl);
     let overlay = null;
 
@@ -72,7 +77,7 @@
     });
 
     map.on(L.Draw.Event.CREATED, async ({ layer }) => {
-      map.addLayer(layer);
+      drawnItems.addLayer(layer);
       const latlngs = layer.getLatLngs()[0];
       const verts = latlngs.map(ll => [ll.lng, ll.lat]);
       const res = await fetch("/api/agrovista/protein", {


### PR DESCRIPTION
## Summary
- Initialize a Leaflet feature group for drawn shapes on the NDVI tool
- Configure draw control with edit options and add drawn layers to the group

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a736873380832ea8b4e33de3d9fa2d