### PR TITLE
Add fit bounds control to NDVI tool

### DIFF
--- a/project/app/modules/agrovista/templates/agrovista/ndvi-tool.j2
+++ b/project/app/modules/agrovista/templates/agrovista/ndvi-tool.j2
@@ -25,6 +25,8 @@
     <button id="enter-fullscreen" class="{{ base_button_classes }}">Pantalla completa</button>
     <button id="exit-fullscreen" class="{{ base_button_classes }} hidden">Salir pantalla completa</button>
 
+    <button id="fit-bounds" class="{{ base_button_classes }}">Ajustar imagen</button>
+
     <label for="uploader" class="{{ base_button_classes }} cursor-pointer">Seleccionar archivo</label>
     <input type="file" id="uploader" accept=".tif,.tiff,.jp2" class="hidden" />
   </div>
@@ -50,7 +52,7 @@
       edit: { featureGroup: drawnItems }
     });
     map.addControl(drawCtl);
-    let overlay = null;
+    let overlay = null, bounds = null;
 
     async function uploadFile(file) {
       const fd = new FormData(); fd.append("file", file);
@@ -66,10 +68,10 @@
         document.getElementById("status").textContent = "Procesando...";
         const meta = await uploadFile(file);
         imgId = meta.id; imgWidth = meta.width; imgHeight = meta.height;
-        const bounds = [[0,0],[imgHeight,imgWidth]];
+        bounds = [[0,0],[imgHeight,imgWidth]];
         if (overlay) map.removeLayer(overlay);
         overlay = L.imageOverlay(`/api/agrovista/image/${imgId}.png`, bounds).addTo(map);
-        map.fitBounds(bounds);
+        fitImage();
         document.getElementById("status").textContent = "Dibuja un polígono o rectángulo sobre el mapa";
       } catch (err) {
         document.getElementById("status").textContent = "Error al procesar el archivo";
@@ -93,6 +95,18 @@
     const workzoneEl = document.getElementById('workzone');
     const enterFsBtn = document.getElementById('enter-fullscreen');
     const exitFsBtn = document.getElementById('exit-fullscreen');
+
+    function fitImage() {
+      if (!overlay) return;
+      map.invalidateSize();
+      const size = map.getSize();
+      const scale = Math.min(size.x / imgWidth, size.y / imgHeight);
+      const minZoom = Math.min(0, Math.floor(Math.log2(scale)));
+      map.setMinZoom(minZoom);
+      map.fitBounds(bounds);
+    }
+
+    document.getElementById('fit-bounds').addEventListener('click', fitImage);
 
     enterFsBtn.addEventListener('click', () => {
       workzoneEl.requestFullscreen();


### PR DESCRIPTION
## Summary
- add `Ajustar imagen` button to NDVI tool
- keep last image bounds to restore map view when clicked
- compute minimum zoom from image and viewport size so the full image fits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a737a64b58832e9e7b5472f2505a03