### PR TITLE
feat: add NDVIImage model and database integration

### DIFF
--- a/project/app/modules/agrovista/__init__.py
+++ b/project/app/modules/agrovista/__init__.py
@@ -1,8 +1,11 @@
 from flask import Blueprint
 
-agrovista = Blueprint("agrovista", __name__, url_prefix='/dashboard/agrovista', template_folder='templates')
-agrovista_api = Blueprint("agrovista_api", __name__, url_prefix='/api/agrovista')
+agrovista = Blueprint(
+    "agrovista",
+    __name__,
+    url_prefix="/dashboard/agrovista",
+    template_folder="templates",
+)
+agrovista_api = Blueprint("agrovista_api", __name__, url_prefix="/api/agrovista")
 
-from . import web_routes, api_routes
-
-
+from . import web_routes, api_routes, models

--- a/project/app/modules/agrovista/models.py
+++ b/project/app/modules/agrovista/models.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from app.extensions import db
+
+
+class NDVIImage(db.Model):
+    """Modelo para almacenar metadatos de imágenes NDVI procesadas."""
+
+    __tablename__ = "ndvi_images"
+
+    id = db.Column(db.String(32), primary_key=True)
+    filename = db.Column(db.String(255), nullable=False)
+    png_path = db.Column(db.String(300), nullable=False)
+    npy_path = db.Column(db.String(300), nullable=False)
+    width = db.Column(db.Integer, nullable=False)
+    height = db.Column(db.Integer, nullable=False)
+    upload_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<NDVIImage {self.id}>"

--- a/project/migrations/versions/b8239d03db7d_add_ndviimage_model.py
+++ b/project/migrations/versions/b8239d03db7d_add_ndviimage_model.py
@@ -1,0 +1,34 @@
+"""add ndviimage model
+
+Revision ID: b8239d03db7d
+Revises: 1d4d593cc253
+Create Date: 2025-08-21 16:24:50.834189
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b8239d03db7d"
+down_revision = "1d4d593cc253"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "ndvi_images",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("png_path", sa.String(length=300), nullable=False),
+        sa.Column("npy_path", sa.String(length=300), nullable=False),
+        sa.Column("width", sa.Integer(), nullable=False),
+        sa.Column("height", sa.Integer(), nullable=False),
+        sa.Column("upload_date", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("ndvi_images")


### PR DESCRIPTION
## Summary
- add NDVIImage SQLAlchemy model for Agrovista module
- persist upload metadata and load images from database
- create Alembic migration for ndvi_images table

## Testing
- `flask db upgrade`
- `black --check app/modules/agrovista/models.py app/modules/agrovista/controller.py app/modules/agrovista/api_routes.py app/modules/agrovista/__init__.py migrations/versions/b8239d03db7d_add_ndviimage_model.py`
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68a7479c5c90832eaae388f988acad36